### PR TITLE
Add support for JSON RPC named parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ class Client {
 
     this.agentOptions = agentOptions;
     this.auth = (password || username) && { pass: password, user: username };
+    this.hasNamedParametersSupport = false;
     this.headers = headers;
     this.host = host;
     this.password = password;
@@ -77,6 +78,7 @@ class Client {
     let unsupported = [];
 
     if (version) {
+      this.hasNamedParametersSupport = semver.satisfies(version, '>=0.14.0');
       unsupported = _.chain(methods)
         .pickBy(method => !semver.satisfies(version, method.version))
         .keys()
@@ -111,6 +113,10 @@ class Client {
     if (_.isFunction(lastArg)) {
       callback = lastArg;
       parameters = _.dropRight(parameters);
+    }
+
+    if (this.hasNamedParametersSupport && parameters.length === 1 && _.isPlainObject(parameters[0])) {
+      parameters = parameters[0];
     }
 
     return Promise.try(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,13 @@ class Client {
     let unsupported = [];
 
     if (version) {
+      // Convert to semver (removing pathes).
+      if (!/[0-9]+\.[0-9]+\.[0-9]+/.test(version)) {
+        throw new Error(`Invalid version "${version}"`, { version });
+      }
+
+      [version] = /[0-9]+\.[0-9]+\.[0-9]+/.exec(version);
+
       this.hasNamedParametersSupport = semver.satisfies(version, '>=0.14.0');
       unsupported = _.chain(methods)
         .pickBy(method => !semver.satisfies(version, method.version))

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -341,6 +341,22 @@ describe('Client', () => {
     }
   });
 
+  it('should throw an error if version is invalid', async () => {
+    try {
+      await new Client({ version: '0.12' }).getHashesPerSec();
+
+      should.fail();
+    } catch (e) {
+      e.should.be.an.instanceOf(Error);
+      e.message.should.equal('Invalid version "0.12"');
+    }
+  });
+
+  it('should not throw an error if version is valid', async () => {
+    await new Client(_.defaults({ version: '0.15.0.1' }, config.bitcoind)).getInfo();
+    await new Client(_.defaults({ version: '0.15.0' }, config.bitcoind)).getInfo();
+  });
+
   it('should throw an error if version does not support a given method', async () => {
     try {
       await new Client({ version: '0.12.0' }).getHashesPerSec();

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -193,6 +193,15 @@ describe('Client', () => {
 
         balance.should.be.a.Number();
       });
+
+      it('should support named parameters', async () => {
+        const balance = await new Client(_.defaults({ version: '0.15.0' }, config.bitcoind)).getBalance({
+          account: '*',
+          minconf: 0
+        });
+
+        balance.should.be.a.Number();
+      });
     });
 
     describe('getDifficulty()', () => {
@@ -239,6 +248,16 @@ describe('Client', () => {
 
       it('should return the most recent list of transactions from all accounts using default count', async () => {
         const transactions = await new Client(config.bitcoind).listTransactions('test');
+
+        transactions.should.be.an.Array().and.empty();
+      });
+
+      it('should support named parameters', async () => {
+        let transactions = await new Client(_.defaults({ version: '0.15.0' }, config.bitcoind)).listTransactions({ account: 'test' });
+
+        transactions.should.be.an.Array().and.empty();
+
+        transactions = await new Client(_.defaults({ version: '0.15.0' }, config.bitcoind)).listTransactions({ account: 'test', count: 15 });
 
         transactions.should.be.an.Array().and.empty();
       });


### PR DESCRIPTION
This PR adds support for JSON RPC named parameters (only available in 0.14.x).

```js
const balance = await new Client(config.bitcoind).getBalance({
  account: '*',
  minconf: 0
});

// Same as:
const balance = await new Client(config.bitcoind).getBalance('*', 0);
```