### PR TITLE
Obfuscate private keys from importmulti request logging

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -90,7 +90,12 @@ export default {
   getWork: { version: '<0.10.0' },
   help: { version: '>=0.1.0' },
   importAddress: { version: '>=0.10.0' },
-  importMulti: { version: '>=0.14.0' },
+  importMulti: {
+    obfuscate: {
+      request: params => set(params, '[0]', map(params[0], request => set(request, 'keys', map(request.keys, () => '******'))))
+    },
+    version: '>=0.14.0'
+  },
   importPrivKey: {
     obfuscate: {
       request: () => ['******']

--- a/test/logging/request-obfuscator_test.js
+++ b/test/logging/request-obfuscator_test.js
@@ -27,6 +27,14 @@ describe('RequestObfuscator', () => {
       request.should.eql({ headers: { authorization: 'Basic ******' } });
     });
 
+    it('should obfuscate all private keys from `request.body` when `method` is `importmulti`', () => {
+      const request = { body: '{"id":"1485369469422","method":"importmulti","params":[[{"address":"foobar","keys":["myprivate1","myprivate2"]},{"address":"foobar2","keys":["myprivate1","myprivate2"]}]]}' };
+
+      obfuscate(request);
+
+      request.should.eql({ body: '{"id":"1485369469422","method":"importmulti","params":[[{"address":"foobar","keys":["******","******"]},{"address":"foobar2","keys":["******","******"]}]]}' });
+    });
+
     it('should obfuscate the private key from `request.body` when `method` is `importprivkey`', () => {
       const request = { body: '{"id":"1485369469422","method":"importprivkey","params":["foobar"]}' };
 


### PR DESCRIPTION
This PR adds private key logs obfuscation when calling `importmulti`.