### PR TITLE
Fix bug when calling REST method with extension `bin`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,8 +138,10 @@ class Client {
     const [[hash, { extension = 'json' } = {}], callback] = source(...args);
 
     return Promise.try(() => {
-      return this.request.getAsync(`/rest/tx/${hash}.${extension}`)
-        .bind(this)
+      return this.request.getAsync({
+        encoding: extension === 'bin' ? null : undefined,
+        url: `/rest/tx/${hash}.${extension}`
+      }).bind(this)
         .then(this.parser.rest);
     }).asCallback(callback);
   }
@@ -154,8 +156,10 @@ class Client {
     const [[hash, { summary = false, extension = 'json' } = {}], callback] = source(...args);
 
     return Promise.try(() => {
-      return this.request.getAsync(`/rest/block${summary ? '/notxdetails/' : '/'}${hash}.${extension}`)
-        .bind(this)
+      return this.request.getAsync({
+        encoding: extension === 'bin' ? null : undefined,
+        url: `/rest/block${summary ? '/notxdetails/' : '/'}${hash}.${extension}`
+      }).bind(this)
         .then(this.parser.rest);
     }).asCallback(callback);
   }
@@ -172,8 +176,10 @@ class Client {
         throw new Error(`Extension "${extension}" is not supported`);
       }
 
-      return this.request.getAsync(`/rest/headers/${count}/${hash}.${extension}`)
-        .bind(this)
+      return this.request.getAsync({
+        encoding: extension === 'bin' ? null : undefined,
+        url: `/rest/headers/${count}/${hash}.${extension}`
+      }).bind(this)
         .then(this.parser.rest);
     }).asCallback(callback);
   }
@@ -205,8 +211,10 @@ class Client {
       return `${outpoint.id}-${outpoint.index}`;
     }).join('/');
 
-    return this.request.getAsync(`/rest/getutxos/checkmempool/${sets}.${extension}`)
-      .bind(this)
+    return this.request.getAsync({
+      encoding: extension === 'bin' ? null : undefined,
+      url: `/rest/getutxos/checkmempool/${sets}.${extension}`
+    }).bind(this)
       .then(this.parser.rest)
       .asCallback(callback);
   }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -387,32 +387,37 @@ describe('Client', () => {
     });
 
     describe('getTransactionByHash()', () => {
-      it('should return a transaction binary-encoded if extension is `bin`', async () => {
-        const transaction = await client.getTransactionByHash('b4dd08f32be15d96b7166fd77afd18aece7480f72af6c9c7f9c5cbeb01e686fe', { extension: 'bin' });
+      it('should return a transaction json-encoded by default', async () => {
+        const [{ txid }] = await client.listUnspent();
+        const transaction = await client.getTransactionByHash(txid);
 
-        new Buffer(transaction, 'binary').toString('hex').should.endWith('206e6f7420666f756e640d0a');
+        transaction.should.have.keys('blockhash', 'locktime', 'hash', 'size', 'txid', 'version', 'vin', 'vout', 'vsize');
       });
 
       it('should return a transaction hex-encoded if extension is `hex`', async () => {
-        const [transaction] = await client.listUnspent();
-        const hex = await client.getTransactionByHash(transaction.txid, { extension: 'hex' });
+        const [{ txid }] = await client.listUnspent();
+        const { hex: rawTransaction } = await client.getTransaction(txid);
+        const hexTransaction = await client.getTransactionByHash(txid, { extension: 'hex' });
 
-        hex.should.endWith('cf900000000\n');
+        hexTransaction.should.equal(`${rawTransaction}\n`);
       });
 
-      it('should return a transaction json-encoded by default', async () => {
-        const [transaction] = await client.listUnspent();
-        const hex = await client.getTransactionByHash(transaction.txid);
+      it('should return a transaction binary-encoded if extension is `bin`', async () => {
+        const [{ txid }] = await client.listUnspent();
+        const binaryTransaction = await client.getTransactionByHash(txid, { extension: 'bin' });
+        const hexTransaction = await client.getTransactionByHash(txid, { extension: 'hex' });
 
-        hex.should.have.keys('blockhash', 'locktime', 'hash', 'size', 'txid', 'version', 'vin', 'vout', 'vsize');
+        binaryTransaction.should.be.instanceOf(Buffer);
+        hexTransaction.should.equal(`${binaryTransaction.toString('hex')}\n`);
       });
     });
 
     describe('getBlockByHash()', () => {
-      it('should return a block binary-encoded if extension is `bin`', async () => {
-        const block = await client.getBlockByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', { extension: 'bin' });
+      it('should return a block json-encoded by default', async () => {
+        const block = await client.getBlockByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', { extension: 'json' });
 
-        new Buffer(block, 'binary').toString('hex').should.equal('0100000000000000000000000000000000000000000000000000000000000000000000003bfdfdfd7a7b12fd7afd2c3e6776fd617ffd1bc8fd51323afdfdfd4b1e5e4afdfd494dfdfd7f20020000000101000000010000000000000000000000000000000000000000000000000000000000000000fdfdfdfd4d04fdfd001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73fdfdfdfd0100fd052a0100000043410467fdfdfdfd5548271967fdfd7130fd105ca828fd3909fd7962fdfd1f61b649fdfd3f4cfd38fdfd5504fd1efd12fd5c384dfdfd0bfd57fd4c702b6bfd1d5ffd00000000');
+        block.should.have.keys('bits', 'chainwork', 'confirmations', 'difficulty', 'hash', 'height', 'mediantime', 'merkleroot', 'nextblockhash', 'nonce', 'size', 'strippedsize', 'time', 'tx', 'version', 'versionHex', 'weight');
+        block.tx.should.matchEach(value => value.should.be.an.Object());
       });
 
       it('should return a block hex-encoded if extension is `hex`', async () => {
@@ -421,11 +426,11 @@ describe('Client', () => {
         block.should.equal('0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f20020000000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000\n');
       });
 
-      it('should return a block json-encoded by default', async () => {
-        const block = await client.getBlockByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', { extension: 'json' });
+      it('should return a block binary-encoded if extension is `bin`', async () => {
+        const block = await client.getBlockByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', { extension: 'bin' });
 
-        block.should.have.keys('bits', 'chainwork', 'confirmations', 'difficulty', 'hash', 'height', 'mediantime', 'merkleroot', 'nextblockhash', 'nonce', 'size', 'strippedsize', 'time', 'tx', 'version', 'versionHex', 'weight');
-        block.tx.should.matchEach(value => value.should.be.an.Object());
+        block.should.be.instanceOf(Buffer);
+        block.toString('hex').should.equal('0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f20020000000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000');
       });
 
       it('should return a block summary json-encoded if `summary` is enabled', async () => {
@@ -437,18 +442,6 @@ describe('Client', () => {
     });
 
     describe('getBlockHeadersByHash()', () => {
-      it('should return block headers binary-encoded if extension is `bin`', async () => {
-        const headers = await client.getBlockHeadersByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', 1, { extension: 'bin' });
-
-        new Buffer(headers, 'binary').toString('hex').should.equal('0100000000000000000000000000000000000000000000000000000000000000000000003bfdfdfd7a7b12fd7afd2c3e6776fd617ffd1bc8fd51323afdfdfd4b1e5e4afdfd494dfdfd7f2002000000');
-      });
-
-      it('should return block headers hex-encoded if extension is `hex`', async () => {
-        const headers = await client.getBlockHeadersByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', 1, { extension: 'hex' });
-
-        headers.should.equal('0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f2002000000\n');
-      });
-
       it('should return a block json-encoded by default', async () => {
         try {
           await client.getBlockHeadersByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', 1, { extension: 'json' });
@@ -458,6 +451,20 @@ describe('Client', () => {
           e.should.be.an.instanceOf(Error);
           e.message.should.equal('Extension "json" is not supported');
         }
+      });
+
+      it('should return block headers hex-encoded if extension is `hex`', async () => {
+        const headers = await client.getBlockHeadersByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', 1, { extension: 'hex' });
+
+        headers.should.equal('0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f2002000000\n');
+      });
+
+      it('should return block headers binary-encoded if extension is `bin`', async () => {
+        const hash = '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206';
+        const binaryHeaders = await client.getBlockHeadersByHash(hash, 1, { extension: 'bin' });
+        const hexHeaders = await client.getBlockHeadersByHash(hash, 1, { extension: 'hex' });
+
+        binaryHeaders.toString('hex').should.equal(`${hexHeaders.toString('hex').replace('\n', '')}`);
       });
     });
 
@@ -470,30 +477,6 @@ describe('Client', () => {
     });
 
     describe('getUnspentTransactionOutputs()', () => {
-      it('should return unspent transaction outputs hex-encoded if extension is `bin`', async () => {
-        const result = await new Client(config.bitcoind).getUnspentTransactionOutputs([{
-          id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
-          index: 0
-        }, {
-          id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
-          index: 1
-        }], { extension: 'bin' });
-
-        new Buffer(result, 'binary').toString('hex').should.endWith('010000');
-      });
-
-      it('should return unspent transaction outputs hex-encoded if extension is `hex`', async () => {
-        const result = await new Client(config.bitcoind).getUnspentTransactionOutputs([{
-          id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
-          index: 0
-        }, {
-          id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
-          index: 1
-        }], { extension: 'hex' });
-
-        result.should.endWith('010000\n');
-      });
-
       it('should return unspent transaction outputs json-encoded by default', async () => {
         const result = await new Client(config.bitcoind).getUnspentTransactionOutputs([{
           id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
@@ -505,6 +488,33 @@ describe('Client', () => {
 
         result.should.have.keys('bitmap', 'chainHeight', 'chaintipHash', 'utxos');
         result.chainHeight.should.be.a.Number();
+      });
+
+      it('should return unspent transaction outputs hex-encoded if extension is `hex`', async () => {
+        const result = await new Client(config.bitcoind).getUnspentTransactionOutputs([{
+          id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+          index: 0
+        }, {
+          id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+          index: 1
+        }], { extension: 'hex' });
+
+        result.should.endWith('10000\n');
+      });
+
+      it('should return unspent transaction outputs binary-encoded if extension is `bin`', async () => {
+        const outputs = [{
+          id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+          index: 0
+        }, {
+          id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+          index: 1
+        }];
+        const binaryUnspents = await new Client(config.bitcoind).getUnspentTransactionOutputs(outputs, { extension: 'bin' });
+        const hexUnspents = await new Client(config.bitcoind).getUnspentTransactionOutputs(outputs, { extension: 'hex' });
+
+        binaryUnspents.should.be.instanceOf(Buffer);
+        hexUnspents.should.equal(`${binaryUnspents.toString('hex')}\n`);
       });
     });
 


### PR DESCRIPTION
This PR fixes a bug when calling REST methods with `extension: bin` which were retrieving invalid data on response buffer.