### PR TITLE
Improve response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This feature is available to all JSON-RPC methods that accept arguments.
 
 ### Floating point number precision in JavaScript
 
-Due to [Javascript's limited floating point precision](http://floating-point-gui.de/), all big numbers (numbers with more than 15 significant digits) are returned as strings to prevent precision loss.
+Due to [JavaScript's limited floating point precision](http://floating-point-gui.de/), all big numbers (numbers with more than 15 significant digits) are returned as strings to prevent precision loss. This includes both the RPC and REST APIs.
 
 ### Version Checking
 By default, all methods are exposed on the client independently of the version it is connecting to. This is the most flexible option as defining methods for unavailable RPC calls does not cause any harm and the library is capable of handling a `Method not found` response error correctly.

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,6 @@ class Client {
     this.request = Promise.promisifyAll(request.defaults({
       agentOptions: this.agentOptions,
       baseUrl: `${this.ssl.enabled ? 'https' : 'http'}://${this.host}:${this.port}`,
-      json: true,
       strictSSL: this.ssl.strict,
       timeout: this.timeout
     }), { multiArgs: true });
@@ -139,7 +138,6 @@ class Client {
       return this.request.postAsync({
         auth: _.pickBy(this.auth, _.identity),
         body: JSON.stringify(body),
-        json: false,
         uri: '/'
       }).bind(this)
         .then(this.parser.rpc);
@@ -158,7 +156,7 @@ class Client {
         encoding: extension === 'bin' ? null : undefined,
         url: `/rest/tx/${hash}.${extension}`
       }).bind(this)
-        .then(this.parser.rest);
+        .then(_.partial(this.parser.rest, extension));
     }).asCallback(callback);
   }
 
@@ -176,7 +174,7 @@ class Client {
         encoding: extension === 'bin' ? null : undefined,
         url: `/rest/block${summary ? '/notxdetails/' : '/'}${hash}.${extension}`
       }).bind(this)
-        .then(this.parser.rest);
+        .then(_.partial(this.parser.rest, extension));
     }).asCallback(callback);
   }
 
@@ -196,7 +194,7 @@ class Client {
         encoding: extension === 'bin' ? null : undefined,
         url: `/rest/headers/${count}/${hash}.${extension}`
       }).bind(this)
-        .then(this.parser.rest);
+        .then(_.partial(this.parser.rest, extension));
     }).asCallback(callback);
   }
 
@@ -210,7 +208,7 @@ class Client {
 
     return this.request.getAsync(`/rest/chaininfo.json`)
       .bind(this)
-      .then(this.parser.rest)
+      .then(_.partial(this.parser.rest, 'json'))
       .asCallback(callback);
   }
 
@@ -231,7 +229,7 @@ class Client {
       encoding: extension === 'bin' ? null : undefined,
       url: `/rest/getutxos/checkmempool/${sets}.${extension}`
     }).bind(this)
-      .then(this.parser.rest)
+      .then(_.partial(this.parser.rest, extension))
       .asCallback(callback);
   }
 
@@ -245,7 +243,7 @@ class Client {
 
     return this.request.getAsync('/rest/mempool/contents.json')
       .bind(this)
-      .then(this.parser.rest)
+      .then(_.partial(this.parser.rest, 'json'))
       .asCallback(callback);
   }
 
@@ -263,7 +261,7 @@ class Client {
 
     return this.request.getAsync('/rest/mempool/info.json')
       .bind(this)
-      .then(this.parser.rest)
+      .then(_.partial(this.parser.rest, 'json'))
       .asCallback(callback);
   }
 }

--- a/test/errors/rpc-error_test.js
+++ b/test/errors/rpc-error_test.js
@@ -3,8 +3,8 @@
  * Module dependencies.
  */
 
-import RpcError from '../../src/errors/rpc-error';
 import { STATUS_CODES } from 'http';
+import RpcError from '../../src/errors/rpc-error';
 import should from 'should';
 
 /**


### PR DESCRIPTION
* Better error handling for both RPC and REST calls.
  * Handle `text/html` and `text/plain` differences from both request types correctly.
  * Proxy response errors as error messages for easier debugging.
  * Add a test for batched requests where one of the request fails.
  * Handle errors in binary-encoded requests.
* Parse REST responses with JSONBigInt to avoid losing precision. This means that some of the response values will now be strings (e.g. the network difficulty on `getDifficulty()`).