### PR TITLE
Add support for named parameters when using the JSON-RPC interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ client.getInfo().then(([body, headers]) => console.log(body, headers));
 const [body, headers] = await client.getInfo();
 ```
 
+## Named parameters
+
+Since version v0.14.0, it is possible to send commands via the JSON-RPC interface using named parameters instead of positional ones. This comes with the advantage of making the order of arguments irrelevant. It also helps improving the readability of certain function calls when leaving out arguments for their default value.
+
+For instance, take the `getBalance()` call written using positional arguments:
+
+```js
+const balance = await new Client().getBalance('*', 0);
+```
+
+It is functionally equivalent to using the named arguments `account` and `minconf`, leaving out `include_watchonly` (defaults to `false`):
+
+```js
+const balance = await new Client().getBalance({
+  account: '*',
+  minconf: 0
+});
+```
+
+This feature is available to all JSON-RPC methods that accept arguments.
+
 ### Floating point number precision in JavaScript
 
 Due to [Javascript's limited floating point precision](http://floating-point-gui.de/), all big numbers (numbers with more than 15 significant digits) are returned as strings to prevent precision loss.

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ class Client {
 
     this.agentOptions = agentOptions;
     this.auth = (password || username) && { pass: password, user: username };
+    this.hasNamedParametersSupport = false;
     this.headers = headers;
     this.host = host;
     this.password = password;
@@ -77,6 +78,17 @@ class Client {
     let unsupported = [];
 
     if (version) {
+      // Capture X.Y.Z when X.Y.Z.A is passed to support oddly formatted Bitcoin Core
+      // versions such as 0.15.0.1.
+      const result = /[0-9]+\.[0-9]+\.[0-9]+/.exec(version);
+
+      if (!result) {
+        throw new Error(`Invalid Version "${version}"`, { version });
+      }
+
+      [version] = result;
+
+      this.hasNamedParametersSupport = semver.satisfies(version, '>=0.14.0');
       unsupported = _.chain(methods)
         .pickBy(method => !semver.satisfies(version, method.version))
         .keys()
@@ -111,6 +123,10 @@ class Client {
     if (_.isFunction(lastArg)) {
       callback = lastArg;
       parameters = _.dropRight(parameters);
+    }
+
+    if (this.hasNamedParametersSupport && parameters.length === 1 && _.isPlainObject(parameters[0])) {
+      parameters = parameters[0];
     }
 
     return Promise.try(() => {


### PR DESCRIPTION
Continuation of https://github.com/ruimarinho/bitcoin-core/pull/33 with improved tests, README updates and version.exec fixes.

This PR adds support for JSON RPC named parameters (only available in Bitcoin Core >=0.14.x).

```js
const balance = await new Client(config.bitcoind).getBalance({
  account: '*',
  minconf: 0
});

// Same as:
const balance = await new Client(config.bitcoind).getBalance('*', 0);
```