### PR TITLE
Add new bitcoin@0.17.0 RPC methods to sign raw transactions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ bitcoin-core:
     - 18443:18443
 
 bitcoin-core-multi-wallet:
-  image: ruimarinho/bitcoin-core:0.15-alpine
+  image: ruimarinho/bitcoin-core:0.17-alpine
   command:
     -printtoconsole
     -regtest=1

--- a/src/methods.js
+++ b/src/methods.js
@@ -137,6 +137,9 @@ export default {
   },
   fundRawTransaction: {
     category: 'rawtransactions',
+    features: {
+      multiwallet: '>=0.15.0'
+    },
     version: '>=0.12.0'
   },
   generate: {
@@ -597,6 +600,23 @@ export default {
       }
     },
     version: '>=0.7.0'
+  },
+  signRawTransactionWithKey: {
+    category: 'rawtransactions',
+    obfuscate: {
+      request: {
+        default: params => set([...params], '[1]', map(params[1], () => '******')),
+        named: params => set(params, 'privkeys', map(params.privkeys || [], () => '******'))
+      }
+    },
+    version: '>=0.17.0'
+  },
+  signRawTransactionWithWallet: {
+    category: 'rawtransactions',
+    features: {
+      multiwallet: '>=0.17.0'
+    },
+    version: '>=0.17.0'
   },
   stop: {
     category: 'control',

--- a/test/logging/request-obfuscator_test.js
+++ b/test/logging/request-obfuscator_test.js
@@ -93,6 +93,32 @@ describe('RequestObfuscator', () => {
       })}}`);
     });
 
+    it('should obfuscate all private keys from `request.body` when `method` is `signrawtransactionwithkey`', () => {
+      const request = { body: '{"id":"1485369469422","method":"signrawtransactionwithkey","params":["foo",["biz", "boz"], "bar"]}', type: 'request' };
+
+      obfuscate(request);
+
+      request.body.should.eql('{"id":"1485369469422","method":"signrawtransactionwithkey","params":["foo",["******","******"],"bar"]}');
+    });
+
+    it('should obfuscate all private keys from `request.body` when `method` is `signrawtransactionwithkey` and RPC is called with named parameters', () => {
+      const request = { body: `{"id":"1485369469422","method":"signrawtransactionwithkey","params":${JSON.stringify({
+        hexstring: 'foo',
+        prevtxs: [],
+        privkeys: ['foo', 'bar'],
+        sighashtype: 'bar'
+      })}}`, type: 'request' };
+
+      obfuscate(request);
+
+      request.body.should.eql(`{"id":"1485369469422","method":"signrawtransactionwithkey","params":${JSON.stringify({
+        hexstring: 'foo',
+        prevtxs: [],
+        privkeys: ['******', '******'],
+        sighashtype: 'bar'
+      })}}`);
+    });
+
     it('should obfuscate the passphrase from `request.body` when `method` is `encryptwallet`', () => {
       const request = { body: '{"id":"1485369469422","method":"encryptwallet","params":["foobar"]}', type: 'request' };
 

--- a/test/rest_test.js
+++ b/test/rest_test.js
@@ -22,11 +22,11 @@ describe('REST', () => {
   before(async () => {
     const [tip] = await client.getChainTips();
 
-    if (tip.height >= 200) {
+    if (tip.height >= 432) {
       return null;
     }
 
-    await client.generate(200);
+    await client.generate(432);
   });
 
   describe('getTransactionByHash()', () => {


### PR DESCRIPTION
Part of https://github.com/ruimarinho/bitcoin-core/issues/77

Not sure this is right. I just copy-pasted the current `signRawTransaction`, changing the version and name, and updated the version for the deprecated `signRawTransaction`.

Tested the "happy path" case — didn't test that the version filters are working, only that I could correctly call this method. That much works well.