### PR TITLE
Remove bluebird dependency and callbacks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ client.getInfo().then((help) => console.log(help));
 
 #### Using callbacks to process the response
 
+Callback support was removed. Since every method returns a `Promise`, [callbackify()](https://nodejs.org/api/util.html#util_util_callbackify_original) (`>node@v8.2.0`) can be used, or for older `node` versions you can use the npm package [callbackify](https://www.npmjs.com/package/callbackify).
+
 ```js
-client.getInfo((error, help) => console.log(help));
+util.callbackify(() => client.getInfo())((error, help) => console.log(help));
 ```
 
 #### Returning headers in the response
@@ -282,22 +284,21 @@ These configuration values may also be set on the `bitcoin.conf` file of your pl
 
 Unlike RPC methods which are automatically exposed on the client, REST ones are handled individually as each method has its own specificity. The following methods are supported:
 
-- [getBlockByHash](#getblockbyhashhash-options-callback)
-- [getBlockHeadersByHash](#getblockheadersbyhashhash-count-options-callback)
-- [getBlockchainInformation](#getblockchaininformationcallback)
+- [getBlockByHash](#getblockbyhashhash-options)
+- [getBlockHeadersByHash](#getblockheadersbyhashhash-count-options)
+- [getBlockchainInformation](#getblockchaininformation)
 - [getMemoryPoolContent](#getmemorypoolcontent)
-- [getMemoryPoolInformation](#getmemorypoolinformationcallback)
-- [getTransactionByHash](#gettransactionbyhashhash-options-callback)
-- [getUnspentTransactionOutputs](#getunspenttransactionoutputsoutpoints-options-callback)
+- [getMemoryPoolInformation](#getmemorypoolinformation)
+- [getTransactionByHash](#gettransactionbyhashhash-options)
+- [getUnspentTransactionOutputs](#getunspenttransactionoutputsoutpoints-options)
 
-#### getBlockByHash(hash, [options], [callback])
+#### getBlockByHash(hash, [options])
 Given a block hash, returns a block, in binary, hex-encoded binary or JSON formats.
 
 ##### Arguments
 1. `hash` _(string)_: The block hash.
 2. `[options]` _(Object)_: The options object.
 3. `[options.extension=json]` _(string)_: Return in binary (`bin`), hex-encoded binary (`hex`) or JSON (`json`) format.
-4. `[callback]` _(Function)_: An optional callback, otherwise a Promise is returned.
 
 ##### Example
 
@@ -305,7 +306,7 @@ Given a block hash, returns a block, in binary, hex-encoded binary or JSON forma
 client.getBlockByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', { extension: 'json' });
 ```
 
-#### getBlockHeadersByHash(hash, count, [options][, callback])
+#### getBlockHeadersByHash(hash, count, [options])
 Given a block hash, returns amount of block headers in upward direction.
 
 ##### Arguments
@@ -313,7 +314,6 @@ Given a block hash, returns amount of block headers in upward direction.
 2. `count` _(number)_: The number of blocks to count in upward direction.
 3. `[options]` _(Object)_: The options object.
 4. `[options.extension=json]` _(string)_: Return in binary (`bin`), hex-encoded binary (`hex`) or JSON (`json`) format.
-5. `[callback]` _(Function)_: An optional callback, otherwise a Promise is returned.
 
 ##### Example
 
@@ -321,23 +321,17 @@ Given a block hash, returns amount of block headers in upward direction.
 client.getBlockHeadersByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', 1, { extension: 'json' });
 ```
 
-#### getBlockchainInformation([callback])
+#### getBlockchainInformation()
 Returns various state info regarding block chain processing.
-
-#### Arguments
-1. `[callback]` _(Function)_: An optional callback, otherwise a Promise is returned.
 
 ##### Example
 
 ```js
-client.getBlockchainInformation([callback]);
+client.getBlockchainInformation();
 ```
 
 #### getMemoryPoolContent()
 Returns transactions in the transaction memory pool.
-
-#### Arguments
-1. `[callback]` _(Function)_: An optional callback, otherwise a Promise is returned.
 
 ##### Example
 
@@ -345,14 +339,11 @@ Returns transactions in the transaction memory pool.
 client.getMemoryPoolContent();
 ```
 
-#### getMemoryPoolInformation([callback])
+#### getMemoryPoolInformation()
 Returns various information about the transaction memory pool. Only supports JSON as output format.
 - size: the number of transactions in the transaction memory pool.
 - bytes: size of the transaction memory pool in bytes.
 - usage: total transaction memory pool memory usage.
-
-#### Arguments
-1. `[callback]` _(Function)_: An optional callback, otherwise a Promise is returned.
 
 ##### Example
 
@@ -360,7 +351,7 @@ Returns various information about the transaction memory pool. Only supports JSO
 client.getMemoryPoolInformation();
 ```
 
-#### getTransactionByHash(hash, [options], [callback])
+#### getTransactionByHash(hash, [options])
 Given a transaction hash, returns a transaction in binary, hex-encoded binary, or JSON formats.
 
 #### Arguments
@@ -368,7 +359,6 @@ Given a transaction hash, returns a transaction in binary, hex-encoded binary, o
 2. `[options]` _(Object)_: The options object.
 3. `[options.summary=false]` _(boolean)_: Whether to return just the transaction hash, thus saving memory.
 4. `[options.extension=json]` _(string)_: Return in binary (`bin`), hex-encoded binary (`hex`) or JSON (`json`) format.
-5. `[callback]` _(Function)_: An optional callback, otherwise a Promise is returned.
 
 ##### Example
 
@@ -376,14 +366,13 @@ Given a transaction hash, returns a transaction in binary, hex-encoded binary, o
 client.getTransactionByHash('b4dd08f32be15d96b7166fd77afd18aece7480f72af6c9c7f9c5cbeb01e686fe', { extension: 'json', summary: false });
 ```
 
-#### getUnspentTransactionOutputs(outpoints, [options], [callback])
+#### getUnspentTransactionOutputs(outpoints, [options])
 Query unspent transaction outputs (UTXO) for a given set of outpoints. See [BIP64](https://github.com/bitcoin/bips/blob/master/bip-0064.mediawiki) for input and output serialisation.
 
 #### Arguments
 1. `outpoints` _(array\<Object\>|Object)_: The outpoint to query in the format `{ id: '<txid>', index: '<index>' }`.
 2. `[options]` _(Object)_: The options object.
 3. `[options.extension=json]` _(string)_: Return in binary (`bin`), hex-encoded binary (`hex`) or JSON (`json`) format.
-4. `[callback]` _(Function)_: An optional callback, otherwise a Promise is returned.
 
 ##### Example
 
@@ -394,7 +383,7 @@ client.getUnspentTransactionOutputs([{
 }, {
   id: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
   index: 1
-}], { extension: 'json' }, [callback])
+}], { extension: 'json' })
 ```
 
 ### SSL

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@uphold/request-logger": "^2.0.0",
-    "bluebird": "^3.4.1",
     "debugnyan": "^1.0.0",
     "json-bigint": "^0.2.0",
     "lodash": "^4.0.0",

--- a/src/parser.js
+++ b/src/parser.js
@@ -50,15 +50,15 @@ export default class Parser {
    * Parse rpc response.
    */
 
-  rpc([response, body]) {
+  rpc(response) {
     // The RPC api returns a `text/html; charset=ISO-8859-1` encoded response with an empty string as the body
     // when an error occurs.
-    if (typeof body === 'string' && response.headers['content-type'] !== 'application/json' && response.statusCode !== 200) {
-      throw new RpcError(response.statusCode, response.statusMessage, { body });
+    if (typeof response.body === 'string' && response.headers['content-type'] !== 'application/json' && response.statusCode !== 200) {
+      throw new RpcError(response.statusCode, response.statusMessage, { body: response.body });
     }
 
     // Parsing the body with custom parser to support BigNumbers.
-    body = parse(body);
+    const body = parse(response.body);
 
     if (!Array.isArray(body)) {
       return getRpcResult(body, { headers: this.headers, response });
@@ -80,28 +80,28 @@ export default class Parser {
     return batch;
   }
 
-  rest(extension, [response, body]) {
+  rest(extension, response) {
     // The REST api returns a `text/plain` encoded response with the error line and the control
     // characters \r\n. For readability and debuggability, the error message is set to this content.
     // When requesting a binary response, the body will be returned as a Buffer representation of
     // this error string.
     if (response.headers['content-type'] !== 'application/json' && response.statusCode !== 200) {
-      if (body instanceof Buffer) {
-        body = body.toString('utf-8');
+      if (response.body instanceof Buffer) {
+        response.body = response.body.toString('utf-8');
       }
 
-      throw new RpcError(response.statusCode, body.replace('\r\n', ''), { body });
+      throw new RpcError(response.statusCode, response.body.replace('\r\n', ''), { body: response.body });
     }
 
     // Parsing the body with custom parser to support BigNumbers.
     if (extension === 'json') {
-      body = parse(body);
+      response.body = parse(response.body);
     }
 
     if (this.headers) {
-      return [body, response.headers];
+      return [response.body, response.headers];
     }
 
-    return body;
+    return response.body;
   }
 }

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -205,16 +205,4 @@ describe('Client', () => {
       });
     });
   });
-
-  describe('callbacks', () => {
-    it('should support callbacks', done => {
-      new Client(config.bitcoin).help((err, help) => {
-        should.not.exist(err);
-
-        help.should.not.be.empty();
-
-        done();
-      });
-    });
-  });
 });

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -73,18 +73,6 @@ describe('Parser', () => {
       headers.should.have.keys('date', 'connection', 'content-length', 'content-type');
     });
 
-    it('should return the response headers if `headers` is enabled using callbacks', done => {
-      new Client(defaults({ headers: true }, config.bitcoin)).getNetworkInfo((err, [info, headers]) => {
-        should.not.exist(err);
-
-        info.should.be.an.Object();
-
-        headers.should.have.keys('date', 'connection', 'content-length', 'content-type');
-
-        done();
-      });
-    });
-
     it('should return the response headers if `headers` is enabled and batching is used', async () => {
       const batch = [
         { method: 'getbalance' },
@@ -94,23 +82,6 @@ describe('Parser', () => {
 
       addresses.should.have.length(batch.length);
       headers.should.have.keys('date', 'connection', 'content-length', 'content-type');
-    });
-
-    it('should return the response headers if `headers` is enabled and batching is used with callbacks', done => {
-      const batch = [
-        { method: 'getbalance' },
-        { method: 'getbalance' }
-      ];
-
-      new Client(defaults({ headers: true }, config.bitcoin)).command(batch, (err, [addresses, headers]) => {
-        should.not.exist(err);
-
-        addresses.should.have.length(batch.length);
-
-        headers.should.have.keys('date', 'connection', 'content-length', 'content-type');
-
-        done();
-      });
     });
   });
 });


### PR DESCRIPTION
This PR removes `bluebird` as a dependency and drops the callback support (still possible to use callbacks via `util.callbackify`).

Closes #85.