### PR TITLE
Add pool option to request.defaults

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,8 @@ class Client {
       agentOptions: this.agentOptions,
       baseUrl: `${this.ssl.enabled ? 'https' : 'http'}://${this.host}:${this.port}`,
       strictSSL: this.ssl.strict,
-      timeout: this.timeout
+      timeout: this.timeout,
+      pool: this.pool
     });
     this.request.getAsync = promisify(this.request.get);
     this.request.postAsync = promisify(this.request.post);


### PR DESCRIPTION
the pool option is required when handling hundreds of requests per seconds.
Without the pool option ESOCKETTIMEDOUT will occur and cancel the queued requests.

https://www.npmjs.com/package/request#requestoptions-callback


> pool - an object describing which agents to use for the request. If this option is omitted the request will use the global agent (as long as your options allow for it). 
> Otherwise, request will search the pool for your custom agent. 
> If no custom agent is found, a new agent will be created and added to the pool. Note: pool is used only when the agent option is not specified.
> A maxSockets property can also be provided on the pool object to set the max number of sockets for all agents created (ex: pool: {maxSockets: Infinity}).
> Note that if you are sending multiple requests in a loop and creating multiple new pool objects, maxSockets will not work as intended. 
> To work around this, either use request.defaults with your pool options or create the pool object with the maxSockets property outside of the loop.