### PR TITLE
Added support for default wallet functions in multiwallet environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       -rest
       -rpcallowip=::/0
       -rpcpassword=bar
+      -wallet
       -wallet=wallet1
       -wallet=wallet2
       -rpcport=18443


### PR DESCRIPTION
As is the library can not access the default wallet when multiple wallets are loaded. It keeps using the URL format: `host:port/` as RPC endpoint when it should be using `host:port/wallet`.

This solution adds a parameter so that the `host:port/wallet` URL will always be used, since this will work regardless of whether multiple wallets are loaded or not.

The expected failing test showcases this, but you can also verify this with `bitcoin-cli` like so ( assuming you start from a state where not other wallets are loaded ):
`./bitcoin-cli -rpcuser=testuser -rpcpassword=testpassword -regtest getbalance`
`./bitcoin-cli -rpcuser=testuser -rpcpassword=testpassword -regtest loadwallet anotherWallet`
`./bitcoin-cli -rpcuser=testuser -rpcpassword=testpassword -regtest getbalance`

After loading a new wallet the `getbalance` call will fail and should be changed to: 
`./bitcoin-cli -rpcwallet -rpcuser=testuser -rpcpassword=testpassword -regtest getbalance`
Which is the same as adding `/wallet` to the RPC endpoint.
