### PR TITLE
Update `mocha@6` to fix critical vulnerability

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 7, 8, 10, 12, 14, 16, 18 ]
+        node: [ 8, 10, 12, 14, 16, 18 ]
     name: Node ${{ matrix.node }}
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "eslint": "4.11.0",
     "eslint-config-uphold": "0.0.1",
-    "mocha": "^4.0.1",
+    "mocha": "^6.0.0",
     "nock": "^9.1.0",
     "nyc": "^11.3.0",
     "pre-commit": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "should": "^13.1.3"
   },
   "engines": {
-    "node": ">=7"
+    "node": ">=8"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
Using `mocha@4`:
```sh
❯ yarn audit --level critical
yarn audit v1.22.19
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ Prototype Pollution in minimist                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimist                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.6                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ mocha                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ mocha > mkdirp > minimist                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1067342                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
11 vulnerabilities found - Packages audited: 508
Severity: 2 Low | 6 Moderate | 2 High | 1 Critical
✨  Done in 0.80s.
```

After updating to `mocha@6`:
```sh
❯ yarn audit --level critical
yarn audit v1.22.19
warning mocha > debug@3.2.6: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning mocha > mkdirp@0.5.4: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
8 vulnerabilities found - Packages audited: 566
Severity: 2 Low | 5 Moderate | 1 High
✨  Done in 1.31s.
```