### PR TITLE
support listDescriptors method for version >=0.22.0

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -541,6 +541,13 @@ module.exports = {
     category: 'network',
     version: '>=0.12.0'
   },
+  listDescriptors: {
+    category: 'wallet',
+    features: {
+      multiwallet: '>=0.22.0'
+    },
+    version: '>=0.22.0'
+  },
   listLabels: {
     category: 'wallet',
     features: {


### PR DESCRIPTION
I have a use case for the `listDescriptors` method in my environment. I noticed that it was missing from the methods list, and I have successfully tested this function with multiple simultaneous wallets.