### PR TITLE
Add restorewallet rpc method for version >=0.23.0

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -656,6 +656,13 @@ module.exports = {
     category: 'wallet',
     version: '>=0.16.0'
   },
+  restoreWallet: {
+    category: 'wallet',
+    features: {
+      multiwallet: '>=23.0.0'
+    },
+    version: '>=23.0.0'
+  },
   saveMempool: {
     category: 'blockchain',
     version: '>=0.16.0'


### PR DESCRIPTION
I recently started using this package as a replacement for bitcoin-cli and noticed it's missing the `restorewallet` rpc method.